### PR TITLE
Speed up nano-staged in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The performance results were generated on a MBP Late 2013, 2,3 GHz Intel Core i7
 
    ```json
    "simple-git-hooks": {
-     "pre-commit": "npx nano-staged"
+     "pre-commit": "./node_modules/.bin/nano-staged"
    }
    ```
 


### PR DESCRIPTION
I found that `npx` adds a visible delay to short commands (like `nano-staged`):

```
➜ time npx nano-staged
0,32s user 0,06s system 117% cpu 0,323 total
➜ time ./node_modules/.bin/nano-staged
0,09s user 0,05s system 139% cpu 0,096 total
```