### PR TITLE
Fix error from packagephobia.com

### DIFF
--- a/bench/size/index.js
+++ b/bench/size/index.js
@@ -4,8 +4,14 @@ import { get } from 'https'
 import c from 'picocolors'
 
 async function getJSON(url) {
+  const options = {
+    headers: {
+      'User-Agent': 'nano-staged',
+    },
+  }
+
   return new Promise((resolve) => {
-    get(url, (res) => {
+    get(url, options, (res) => {
       let text = ''
       res.on('data', (chunk) => {
         text += chunk


### PR DESCRIPTION
Looks like they require to give a user-agent.

Output is now:

```
$ pnpm run bench

> nano-staged@0.8.0 bench /Users/Sites/github/nano-staged
> node bench/running-time/index.js && node bench/size/index.js

- lint-staged 1.390 ms
+ nano-staged 0.779 ms
Data from packagephobia.com
- lint-staged   2190 kB
+ nano-staged     48 kB
```

Before:

```
$ pnpm bench

> nano-staged@0.8.0 bench /Users/Sites/github/nano-staged
> node bench/running-time/index.js && node bench/size/index.js

- lint-staged 1.638 ms
+ nano-staged 0.730 ms
Data from packagephobia.com
- lint-staged   2190 kB
undefined:1
Too many requests from unknown user-agent. See https://github.com/styfle/packagephobia/blob/main/API.md
^

SyntaxError: Unexpected token 'T', "Too many r"... is not valid JSON
    at JSON.parse (<anonymous>)
    at IncomingMessage.<anonymous> (file:///Users/Sites/github/nano-staged/bench/size/index.js:14:22)
    at IncomingMessage.emit (node:events:531:35)
    at endReadableNT (node:internal/streams/readable:1696:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)

Node.js v20.18.0
 ELIFECYCLE  Command failed with exit code 1.
```