### PR TITLE
Add `--fail-on-changes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,10 @@ Run commands on files changed between the working tree and the index or a tree, 
 
 Will allow creating an empty commit.
 
+#### `--fail-on-changes`
+
+Fail with exit code 1 when tasks modify tracked files. This flag also disables staging of changes made by tasks and skips reverting to the original state on failure so you can review and stage changes manually.
+
 #### `--quiet`
 
 Shows only that work is done and errors occured.

--- a/lib/bin.js
+++ b/lib/bin.js
@@ -19,6 +19,7 @@ Options:
   -c, --config <path>  Path to config file
   -u, --unstaged       Run on unstaged changes
   --allow-empty        Allow empty commits
+  --fail-on-changes    Fail with exit code 1 when tasks modify tracked files
   --diff <a> <b>       Run on diff between two revisions
   --quiet              Suppress output
   --bail               Exit on first error
@@ -46,6 +47,8 @@ function run() {
       options.unstaged = true
     } else if (arg === '--allow-empty') {
       options.allowEmpty = true
+    } else if (arg === '--fail-on-changes') {
+      options.failOnChanges = true
     } else if (arg === '--diff') {
       options.diff = []
     } else if (arg === '--quiet') {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -5,6 +5,7 @@ const MESSAGES = {
   noGitRepo: () => 'Nano Staged didn’t find git directory.',
   noFiles: (type) => `No ${type} files found.`,
   noMatchingFiles: () => 'No files match any configured task.',
+  failOnChanges: () => 'Tasks modified files and --fail-on-changes was used!',
 }
 
 export class NanoStagedError extends Error {

--- a/lib/git-workflow.js
+++ b/lib/git-workflow.js
@@ -9,6 +9,7 @@ export function createGitWorkflow({ allowEmpty = false, dotPath = '', rootPath =
     unstaged: resolve(dotPath, './nano-staged_partial.patch'),
     original: resolve(dotPath, './nano-staged.patch'),
   }
+  let initialDiffHash
 
   const workflow = {
     hasPatch(path = '') {
@@ -43,6 +44,14 @@ export function createGitWorkflow({ allowEmpty = false, dotPath = '', rootPath =
           throw e
         }
       }
+    },
+
+    async captureInitialDiffHash() {
+      initialDiffHash = await git.diffHash()
+    },
+
+    async hasChangesSinceInitialDiff() {
+      return initialDiffHash !== (await git.diffHash())
     },
 
     async applyModifications(files = []) {

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import { join, normalize, resolve } from 'path'
 import fs from 'fs'
 
@@ -64,6 +65,11 @@ export function createGit(cwd = process.cwd()) {
       } catch (e) {
         throw e
       }
+    },
+
+    async diffHash(opts = {}) {
+      const diff = await git.exec(['diff', '--patch', '--unified=0'], opts)
+      return createHash('sha256').update(diff).digest('hex')
     },
 
     async diff(fileName, files = [], opts = {}) {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -69,6 +69,13 @@ export interface Options {
    * @default false
    */
   quiet?: boolean
+
+  /**
+   * Fail when tasks modify tracked files.
+   *
+   * @default false
+   */
+  failOnChanges?: boolean
 }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ export default async function (options) {
     diff: false,
     quiet: false,
     bail: false,
+    failOnChanges: false,
     ...options,
   }
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -6,6 +6,7 @@ import { NanoStagedError } from './errors.js'
 
 export function createRunner({
   allowEmpty,
+  failOnChanges,
   git_paths,
   config,
   stream,
@@ -47,6 +48,7 @@ export function createRunner({
       let enabled = false
       let revert = false
       let clear = true
+      let failedOnTaskChanges = false
       let errors = []
       let tasks = []
 
@@ -76,6 +78,14 @@ export function createRunner({
       })
 
       tasks.push({
+        title: `Capturing initial diff hash`,
+        run: async () => {
+          await gitWorkflow.captureInitialDiffHash()
+        },
+        skipped: () => enabled || revert || !failOnChanges,
+      })
+
+      tasks.push({
         title: `Running tasks for ${type} files`,
         run: async (task) => {
           task.tasks = cmdTasks
@@ -91,6 +101,18 @@ export function createRunner({
       })
 
       tasks.push({
+        title: `Checking for task modifications`,
+        run: async () => {
+          if (await gitWorkflow.hasChangesSinceInitialDiff()) {
+            failedOnTaskChanges = true
+            clear = false
+            throw new NanoStagedError('failOnChanges')
+          }
+        },
+        skipped: () => enabled || revert || !failOnChanges,
+      })
+
+      tasks.push({
         title: `Applying modifications from tasks`,
         run: async () => {
           try {
@@ -100,7 +122,8 @@ export function createRunner({
             throw e
           }
         },
-        skipped: () => enabled || revert || type === 'unstaged' || type === 'diff',
+        skipped: () =>
+          enabled || revert || failedOnTaskChanges || type === 'unstaged' || type === 'diff',
       })
 
       tasks.push({
@@ -126,7 +149,7 @@ export function createRunner({
             throw e
           }
         },
-        skipped: () => enabled || !revert,
+        skipped: () => enabled || !revert || failOnChanges,
       })
 
       tasks.push({

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -35,4 +35,9 @@ test('has error for task', () => {
   is(err.message, 'task error')
 })
 
+test('has error for --fail-on-changes', () => {
+  let err = new NanoStagedError('failOnChanges')
+  is(err.message, 'Tasks modified files and --fail-on-changes was used!')
+})
+
 test.run()

--- a/test/git-workflow.test.js
+++ b/test/git-workflow.test.js
@@ -238,4 +238,31 @@ test('hasPatch return false when no patch file', async () => {
   is(gitWorkflow.hasPatch('./test.patch'), false)
 })
 
+test('should detect changes since initial diff', async () => {
+  let gitWorkflow = createGitWorkflow({
+    dotPath: resolve(cwd, './.git'),
+    allowEmpty: false,
+    rootPath: cwd,
+  })
+
+  await writeFile('README.md', '# Test\n# Staged', cwd)
+  await execGit(['add', 'README.md'])
+  await gitWorkflow.captureInitialDiffHash()
+  await writeFile('README.md', '# Test\n# Modified by task', cwd)
+
+  is(await gitWorkflow.hasChangesSinceInitialDiff(), true)
+})
+
+test('should not detect changes since initial diff when diff is unchanged', async () => {
+  let gitWorkflow = createGitWorkflow({
+    dotPath: resolve(cwd, './.git'),
+    allowEmpty: false,
+    rootPath: cwd,
+  })
+
+  await gitWorkflow.captureInitialDiffHash()
+
+  is(await gitWorkflow.hasChangesSinceInitialDiff(), false)
+})
+
 test.run()

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -262,6 +262,130 @@ test('should restoreOriginalState error', async () => {
   }
 })
 
+test('should fail when tasks modify files with failOnChanges', async () => {
+  const git_paths = { root: 'dir', dot: 'dir/.git' }
+  const files = { working: ['a.js'], deleted: [], changed: ['a.js'] }
+
+  const { createRunner } = await esmock('../lib/runner.js', {
+    '../lib/cmd-runner.js': {
+      createCmdRunner: () => ({
+        generateCmdTasks: async () => [{ file_count: 1 }],
+        run: async () => Promise.resolve(),
+      }),
+    },
+    '../lib/git-workflow.js': {
+      createGitWorkflow: () => ({
+        backupOriginalState: async () => Promise.resolve(),
+        backupUnstagedFiles: async () => Promise.resolve(),
+        captureInitialDiffHash: async () => Promise.resolve(),
+        hasChangesSinceInitialDiff: async () => true,
+        applyModifications: async () => Promise.resolve(),
+        restoreUnstagedFiles: async () => Promise.resolve(),
+        restoreOriginalState: async () => Promise.resolve(),
+        cleanUp: async () => Promise.resolve(),
+      }),
+    },
+  })
+
+  try {
+    await createRunner({ stream: stdout, git_paths, files, failOnChanges: true }).run()
+  } catch (error) {
+    is(error[0].message, 'Tasks modified files and --fail-on-changes was used!')
+    is(
+      stdout.out,
+      '\x1B[32m√\x1B[39m Preparing nano-staged\n' +
+        '\x1B[32m√\x1B[39m Backing up unstaged changes for staged files\n' +
+        '\x1B[32m√\x1B[39m Capturing initial diff hash\n' +
+        '\x1B[31m×\x1B[39m Checking for task modifications\n' +
+        '\x1B[32m√\x1B[39m Restoring unstaged changes for staged files\n',
+    )
+  }
+})
+
+test('should fail in diff mode when tasks modify files with failOnChanges', async () => {
+  const git_paths = { root: 'dir', dot: 'dir/.git' }
+  const files = { working: ['a.js'], deleted: [], changed: ['a.js'] }
+
+  const { createRunner } = await esmock('../lib/runner.js', {
+    '../lib/cmd-runner.js': {
+      createCmdRunner: () => ({
+        generateCmdTasks: async () => [{ file_count: 1 }],
+        run: async () => Promise.resolve(),
+      }),
+    },
+    '../lib/git-workflow.js': {
+      createGitWorkflow: () => ({
+        backupOriginalState: async () => Promise.resolve(),
+        captureInitialDiffHash: async () => {},
+        hasChangesSinceInitialDiff: async () => true,
+        applyModifications: async () => Promise.resolve(),
+        restoreOriginalState: async () => Promise.resolve(),
+        cleanUp: async () => Promise.resolve(),
+      }),
+    },
+  })
+
+  try {
+    await createRunner({
+      stream: stdout,
+      git_paths,
+      files,
+      type: 'diff',
+      failOnChanges: true,
+    }).run()
+  } catch (error) {
+    is(error[0].message, 'Tasks modified files and --fail-on-changes was used!')
+    is(
+      stdout.out,
+      '\x1B[32m√\x1B[39m Preparing nano-staged\n' +
+        '\x1B[32m√\x1B[39m Capturing initial diff hash\n' +
+        '\x1B[31m×\x1B[39m Checking for task modifications\n',
+    )
+  }
+})
+
+test('should fail in unstaged mode when tasks modify files with failOnChanges', async () => {
+  const git_paths = { root: 'dir', dot: 'dir/.git' }
+  const files = { working: ['a.js'], deleted: [], changed: ['a.js'] }
+
+  const { createRunner } = await esmock('../lib/runner.js', {
+    '../lib/cmd-runner.js': {
+      createCmdRunner: () => ({
+        generateCmdTasks: async () => [{ file_count: 1 }],
+        run: async () => Promise.resolve(),
+      }),
+    },
+    '../lib/git-workflow.js': {
+      createGitWorkflow: () => ({
+        backupOriginalState: async () => Promise.resolve(),
+        captureInitialDiffHash: async () => Promise.resolve(),
+        hasChangesSinceInitialDiff: async () => true,
+        applyModifications: async () => Promise.resolve(),
+        restoreOriginalState: async () => Promise.resolve(),
+        cleanUp: async () => Promise.resolve(),
+      }),
+    },
+  })
+
+  try {
+    await createRunner({
+      stream: stdout,
+      git_paths,
+      files,
+      type: 'unstaged',
+      failOnChanges: true,
+    }).run()
+  } catch (error) {
+    is(error[0].message, 'Tasks modified files and --fail-on-changes was used!')
+    is(
+      stdout.out,
+      '\x1B[32m√\x1B[39m Preparing nano-staged\n' +
+        '\x1B[32m√\x1B[39m Capturing initial diff hash\n' +
+        '\x1B[31m×\x1B[39m Checking for task modifications\n',
+    )
+  }
+})
+
 test('should cleanUp error', async () => {
   const git_paths = { root: 'dir', dot: 'dir/.git' }
   const files = { working: ['a.js'], deleted: [], changed: ['a.js'] }


### PR DESCRIPTION
When running nano-staged in CI as a gate before merging, it currently won't fail when e.g. `prettier --write` makes changes to a file.

This PR adds a `--fail-on-changes` argument which ensures an error is thrown when tasks edit code.

Aligns with functionality in lint-staged https://github.com/lint-staged/lint-staged#--fail-on-changes